### PR TITLE
feat: show bookmarked novels in Library screen

### DIFF
--- a/app/src/main/java/gb/coding/lightnovel/MainActivity.kt
+++ b/app/src/main/java/gb/coding/lightnovel/MainActivity.kt
@@ -27,6 +27,7 @@ import gb.coding.lightnovel.reader.presentation.browse.BrowseViewModel
 import gb.coding.lightnovel.reader.presentation.chapter_reader.ChapterReaderEvent
 import gb.coding.lightnovel.reader.presentation.chapter_reader.ChapterReaderScreen
 import gb.coding.lightnovel.reader.presentation.chapter_reader.ChapterReaderViewModel
+import gb.coding.lightnovel.reader.presentation.library.LibraryEvent
 import gb.coding.lightnovel.reader.presentation.library.LibraryScreen
 import gb.coding.lightnovel.reader.presentation.library.LibraryViewModel
 import gb.coding.lightnovel.reader.presentation.novel_detail.NovelDetailEvent
@@ -117,11 +118,19 @@ class MainActivity : ComponentActivity() {
                             println("LibraryScreen | Composable")
                             val state by libraryViewModel.state.collectAsStateWithLifecycle()
 
+                            LaunchedEffect(Unit) {
+                                libraryViewModel.events.collect { event ->
+                                    when (event) {
+                                        is LibraryEvent.Navigate2NovelDetail -> {
+                                            navController.navigate(Route.NovelDetail(event.novelId))
+                                        }
+                                    }
+                                }
+                            }
+
                             LibraryScreen(
                                 state = state,
-                                onAction = {
-                                    navController.navigate(Route.NovelDetail)
-                                },
+                                onAction = libraryViewModel::onAction,
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .padding(innerPadding)

--- a/app/src/main/java/gb/coding/lightnovel/MainActivity.kt
+++ b/app/src/main/java/gb/coding/lightnovel/MainActivity.kt
@@ -21,7 +21,6 @@ import androidx.navigation.compose.rememberNavController
 import gb.coding.lightnovel.core.navigation.Route
 import gb.coding.lightnovel.core.navigation.bottomNavItems
 import gb.coding.lightnovel.core.navigation.components.BottomNavigationBar
-import gb.coding.lightnovel.reader.data.mock.MockChapters
 import gb.coding.lightnovel.reader.presentation.browse.BrowseEvent
 import gb.coding.lightnovel.reader.presentation.browse.BrowseScreen
 import gb.coding.lightnovel.reader.presentation.browse.BrowseViewModel
@@ -29,7 +28,7 @@ import gb.coding.lightnovel.reader.presentation.chapter_reader.ChapterReaderEven
 import gb.coding.lightnovel.reader.presentation.chapter_reader.ChapterReaderScreen
 import gb.coding.lightnovel.reader.presentation.chapter_reader.ChapterReaderViewModel
 import gb.coding.lightnovel.reader.presentation.library.LibraryScreen
-import gb.coding.lightnovel.reader.presentation.library.LibraryState
+import gb.coding.lightnovel.reader.presentation.library.LibraryViewModel
 import gb.coding.lightnovel.reader.presentation.novel_detail.NovelDetailEvent
 import gb.coding.lightnovel.reader.presentation.novel_detail.NovelDetailScreen
 import gb.coding.lightnovel.reader.presentation.novel_detail.NovelDetailViewModel
@@ -67,6 +66,13 @@ class MainActivity : ComponentActivity() {
 
                 val browseViewModel = koinViewModel<BrowseViewModel>()
                 val browseState by browseViewModel.state.collectAsStateWithLifecycle()
+
+                /*
+                 * TODO: Optimize loading novels from local database.
+                 *  When loading the app there's small delay before the novels are loaded, so it shows for a brief moment, an empty state screen.
+                 *  There must be a way where the splash screen only goes out when the novels are loaded.
+                 */
+                val libraryViewModel = koinViewModel<LibraryViewModel>()
 
                 LaunchedEffect(Unit) {
                     browseViewModel.events.collect { event ->
@@ -108,8 +114,11 @@ class MainActivity : ComponentActivity() {
                         startDestination = Route.Library,
                     ) {
                         composable<Route.Library> {
+                            println("LibraryScreen | Composable")
+                            val state by libraryViewModel.state.collectAsStateWithLifecycle()
+
                             LibraryScreen(
-                                state = LibraryState(),
+                                state = state,
                                 onAction = {
                                     navController.navigate(Route.NovelDetail)
                                 },

--- a/app/src/main/java/gb/coding/lightnovel/reader/data/mock/MockNovels.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/data/mock/MockNovels.kt
@@ -13,4 +13,26 @@ object MockNovels {
         coverImage = "https://us-east-1.linodeobjects.com/novelmania/uploads/novel/cover/63/capa_ir.jpg",
         description = "Wang Lin é um garoto muito esperto com parentes amáveis. Embora ele e seus pais sejam evitados pelo resto dos seus parentes, seus pais sempre mantiveram muita esperança de que ele algum dia se tornará alguém grandioso. Um dia, Wang Lin repentinamente ganhou uma chance de trilhar o caminho de um imortal, mas descobriu que ele apenas tinha um talento medíocre no máximo. Acompanhe Wang Lin enquanto ele supera sua falta de talento e trilha o caminho em direção a tornar-se um verdadeiro imortal!",
     )
+
+    val sample2 = Novel(
+        id = "2",
+        language = LanguageCode.BRAZILIAN_PORTUGUESE,
+        title = "Alya às Vezes Esconde seus Sentimentos em Russo",
+        author = "SunSunSun",
+        status = "Ativo",
+        coverImage = "https://us-east-1.linodeobjects.com/novelmania/uploads/novel/cover/290/alya_v5_capa_1.jpg",
+        description = "Masachika Kuze senta-se ao lado de Alya Mikhailovna Kujou, uma garota de ascendência russa e japonesa. Ela é bonita, inteligente e uma aluna excepcional em diversas áreas, enquanto Masachika é um nerd e conhecido por ser preguiçoso. Ele é um alvo fácil para seus, aparentemente, ríspidos comentários em russo, que a deixa muito feliz por ninguém conseguir traduzir… exceto por Masachika que consegue entender o que ela realmente está dizendo!"
+    )
+
+    val sample3 = Novel(
+        id = "3",
+        language = LanguageCode.BRAZILIAN_PORTUGUESE,
+        title = "Soberbo Deus da Alquimia",
+        author = "Ji Xiao Zei",
+        status = "Ativo",
+        coverImage = "https://us-east-1.linodeobjects.com/novelmania/uploads/novel/cover/83/capa_sda.jpg",
+        description = "Chen Xiang tinha sido golpeado com infortúnio, ele nasceu sem uma veia espiritual, então ele não podia praticar artes marciais. No entanto foi sua sorte que ele teve um encontro fatídico com algumas beldades misteriosas. Isso fez sua vida dar uma volta para melhor no caminho do cultivo e alquimia. Esse mundo novo e excitante é cheio de imortais, demônios e deuses e, bestas místicas celestiais. Enquanto ele começa sua aventura ao longo da vida, ele cruza com muitos segredos e mistérios escondidos no seu mundo. Explore com nosso herói como ele contemplar esses tentadores e profundos mistérios e atingir o pico do caminho marcial, enquanto ele flerta com mulheres, faz amizades, desafia lordes, imortais e demônios do mundo marcial."
+    )
+
+    val samples = listOf(sample, sample2, sample3)
 }

--- a/app/src/main/java/gb/coding/lightnovel/reader/data/repository/BookmarkedNovelRepositoryImpl.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/data/repository/BookmarkedNovelRepositoryImpl.kt
@@ -1,10 +1,12 @@
 package gb.coding.lightnovel.reader.data.repository
 
 import gb.coding.lightnovel.core.domain.mapper.toBookmarkedNovel
+import gb.coding.lightnovel.core.domain.mapper.toNovel
 import gb.coding.lightnovel.reader.data.local.BookmarkedNovelDao
 import gb.coding.lightnovel.reader.domain.models.Novel
 import gb.coding.lightnovel.reader.domain.repository.BookmarkedNovelRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class BookmarkedNovelRepositoryImpl(
     private val bookmarkedNovelDao: BookmarkedNovelDao
@@ -26,6 +28,11 @@ class BookmarkedNovelRepositoryImpl(
     }
 
     override fun getAllNovels(): Flow<List<Novel>> {
-        TODO("Not yet implemented")
+        println("BookmarkedNovelRepositoryImpl | Getting all bookmarked novels...")
+        return bookmarkedNovelDao.getAllNovels().map { bookmarkedNovels ->
+            bookmarkedNovels.map { bookmarkedNovel ->
+                bookmarkedNovel.toNovel()
+            }
+        }
     }
 }

--- a/app/src/main/java/gb/coding/lightnovel/reader/di/AppModule.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/di/AppModule.kt
@@ -9,6 +9,7 @@ import gb.coding.lightnovel.reader.domain.repository.BookmarkedNovelRepository
 import gb.coding.lightnovel.reader.domain.repository.NovelRepository
 import gb.coding.lightnovel.reader.presentation.browse.BrowseViewModel
 import gb.coding.lightnovel.reader.presentation.chapter_reader.ChapterReaderViewModel
+import gb.coding.lightnovel.reader.presentation.library.LibraryViewModel
 import gb.coding.lightnovel.reader.presentation.novel_detail.NovelDetailViewModel
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.postgrest.Postgrest
@@ -43,4 +44,5 @@ val appModule = module {
     viewModelOf(::BrowseViewModel)
     viewModelOf(::NovelDetailViewModel)
     viewModelOf(::ChapterReaderViewModel)
+    viewModelOf(::LibraryViewModel)
 }

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryEvent.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryEvent.kt
@@ -1,0 +1,5 @@
+package gb.coding.lightnovel.reader.presentation.library
+
+sealed interface LibraryEvent {
+    data class Navigate2NovelDetail(val novelId: String): LibraryEvent
+}

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryScreen.kt
@@ -70,13 +70,13 @@ fun LibraryScreen(
                         .padding(vertical = 12.dp)
                         .fillMaxWidth(),
                     placeholder = { Text("Pesquisar na biblioteca...") },
-                    onSearch = TODO()
+                    onSearch = { TODO() }
                 )
             }
 
             items(state.novels) { novel ->
                 LibraryNovelCard(
-                    novel = MockNovels.sample,
+                    novel = novel,
                     onClick = { onAction(LibraryAction.OnNovelClicked(it)) },
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -128,7 +128,9 @@ fun LibraryScreen(
 private fun LibraryScreenPreview() {
     LightNovelTheme {
         LibraryScreen(
-            state = LibraryState(),
+            state = LibraryState(
+                novels = MockNovels.samples
+            ),
             onAction = {},
             modifier = Modifier.fillMaxSize()
         )

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryViewModel.kt
@@ -3,8 +3,10 @@ package gb.coding.lightnovel.reader.presentation.library
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import gb.coding.lightnovel.reader.domain.repository.BookmarkedNovelRepository
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -14,6 +16,9 @@ class LibraryViewModel(
 
     private val _state = MutableStateFlow(LibraryState())
     val state = _state.asStateFlow()
+
+    private val _events = Channel<LibraryEvent>()
+    val events = _events.receiveAsFlow()
 
     init {
         println("LibraryViewModel init")
@@ -31,7 +36,12 @@ class LibraryViewModel(
 
     fun onAction(action: LibraryAction) {
         when (action) {
-            is LibraryAction.OnNovelClicked -> TODO()
+            is LibraryAction.OnNovelClicked -> {
+                println("LibraryViewModel | OnNovelClicked | Clicked on novel \"${action.novel.title}\" - ${action.novel.id}")
+                viewModelScope.launch {
+                    _events.send(LibraryEvent.Navigate2NovelDetail(action.novel.id))
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryViewModel.kt
@@ -1,0 +1,37 @@
+package gb.coding.lightnovel.reader.presentation.library
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import gb.coding.lightnovel.reader.domain.repository.BookmarkedNovelRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class LibraryViewModel(
+    private val bookmarkedNovelRepository: BookmarkedNovelRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(LibraryState())
+    val state = _state.asStateFlow()
+
+    init {
+        println("LibraryViewModel init")
+        viewModelScope.launch {
+            bookmarkedNovelRepository.getAllNovels()
+                .collect { bookmarkedNovels ->
+                    _state.update {
+                        it.copy(
+                            novels = bookmarkedNovels
+                        )
+                    }
+                }
+        }
+    }
+
+    fun onAction(action: LibraryAction) {
+        when (action) {
+            is LibraryAction.OnNovelClicked -> TODO()
+        }
+    }
+}

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/components/LibraryNovelCard.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/components/LibraryNovelCard.kt
@@ -1,19 +1,22 @@
 package gb.coding.lightnovel.reader.presentation.library.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
 import gb.coding.lightnovel.R
 import gb.coding.lightnovel.reader.data.mock.MockNovels
 import gb.coding.lightnovel.reader.domain.models.Novel
@@ -25,27 +28,24 @@ fun LibraryNovelCard(
     onClick: (Novel) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier.clickable{
-        // TODO: Implement with actual data
-        //onAction(LibraryAction.OnNovelClicked(MockNovels.novel))
-        onClick(novel)
-    }) {
-        Image(
-            painter = painterResource(R.drawable.image_placeholder),
+    Column(modifier.clickable { onClick(novel) }) {
+        AsyncImage(
+            model = if (LocalInspectionMode.current) R.drawable.image_placeholder else novel.coverImage,
             contentDescription = null,
-            modifier = Modifier.clip(RoundedCornerShape(8.dp))
+            contentScale = ContentScale.FillBounds,
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
         )
         Text(
-            text = "Renegade Immortal",
+            text = novel.title,
             fontSize = 12.sp,
-            fontWeight = FontWeight.Medium,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun LibraryNovelCardPreview() {
     LightNovelTheme {

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/components/LibraryNovelCard.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/components/LibraryNovelCard.kt
@@ -32,8 +32,9 @@ fun LibraryNovelCard(
         AsyncImage(
             model = if (LocalInspectionMode.current) R.drawable.image_placeholder else novel.coverImage,
             contentDescription = null,
-            contentScale = ContentScale.FillBounds,
             modifier = Modifier
+                // Standard size of each novel cover
+                .aspectRatio(393f / 562f)
                 .clip(RoundedCornerShape(8.dp))
         )
         Text(


### PR DESCRIPTION
This PR introduces full support for displaying and navigating bookmarked novels from the `LibraryScreen`.

### Features:
- Display Bookmarked Novels
  - Implemented getAllNovels() in BookmarkedNovelRepositoryImpl to fetch and map Room entities to domain Novel objects.
  - Created LibraryViewModel to manage UI state and provide bookmarked novels to the screen.
  - Updated LibraryScreen to observe and display the list using LibraryNovelCard.
- Navigation to Novel Detail 
  - Introduced `LibraryEvent.Navigate2NovelDetail` to enable navigation from the library to a selected novel.
  - `MainActivity` now listens to `LibraryViewModel` events and navigates accordingly using the novel's ID.
- UI Bug Fix
  - Fixed an issue where novel cards would stretch vertically after returning from the detail screen by enforcing a stable .aspectRatio() in LibraryNovelCard.