### PR TITLE
feat: implement library search functionality

### DIFF
--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryAction.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryAction.kt
@@ -4,4 +4,5 @@ import gb.coding.lightnovel.reader.domain.models.Novel
 
 sealed interface LibraryAction {
     data class OnNovelClicked(val novel: Novel) : LibraryAction
+    data class OnSearchQueryChanged(val query: String) : LibraryAction
 }

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryScreen.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryScreen.kt
@@ -41,8 +41,6 @@ fun LibraryScreen(
     onAction: (LibraryAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var searchText by rememberSaveable { mutableStateOf("") }
-
     val numberColumns = 3
 
     LazyVerticalGrid(
@@ -61,20 +59,20 @@ fun LibraryScreen(
             )
         }
         
-        if (state.novels.isNotEmpty()) {
+        if (state.filteredNovels.isNotEmpty()) {
             item(span = { GridItemSpan(numberColumns) }) {
                 SearchBar(
-                    text = searchText,
-                    onTextChange = { searchText = it },
+                    text = state.searchQuery,
+                    onTextChange = { onAction(LibraryAction.OnSearchQueryChanged(it)) },
                     modifier = Modifier
                         .padding(vertical = 12.dp)
                         .fillMaxWidth(),
                     placeholder = { Text("Pesquisar na biblioteca...") },
-                    onSearch = { TODO() }
+                    onSearch = { }
                 )
             }
 
-            items(state.novels) { novel ->
+            items(state.filteredNovels) { novel ->
                 LibraryNovelCard(
                     novel = novel,
                     onClick = { onAction(LibraryAction.OnNovelClicked(it)) },
@@ -129,7 +127,8 @@ private fun LibraryScreenPreview() {
     LightNovelTheme {
         LibraryScreen(
             state = LibraryState(
-                novels = MockNovels.samples
+                novels = MockNovels.samples,
+                filteredNovels = MockNovels.samples,
             ),
             onAction = {},
             modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryState.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/library/LibraryState.kt
@@ -4,5 +4,6 @@ import gb.coding.lightnovel.reader.domain.models.Novel
 
 data class LibraryState(
     val novels: List<Novel> = emptyList(),
-    val searchText: String = "",
+    val filteredNovels: List<Novel> = emptyList(),
+    val searchQuery: String = "",
 )


### PR DESCRIPTION
This commit introduces search functionality to the library screen.

Key changes:
- Added `OnSearchQueryChanged` to `LibraryAction`.
- Added `searchQuery` and `filteredNovels` to `LibraryState`.
- `LibraryViewModel` now handles `OnSearchQueryChanged` to filter novels based on the query.
- `LibraryScreen` now displays a search bar and uses `filteredNovels` for the novel list.
- `LibraryViewModel` now initializes `filteredNovels` with all novels.