### PR TITLE
feat: Add Word Highlighting with Knowledge Levels to Chapter Reader

### DIFF
--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/gb/coding/lightnovel/core/domain/model/KnowledgeLevel.kt
+++ b/app/src/main/java/gb/coding/lightnovel/core/domain/model/KnowledgeLevel.kt
@@ -1,0 +1,37 @@
+package gb.coding.lightnovel.core.domain.model
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+enum class KnowledgeLevel(val id: Int, val label: String) {
+    IGNORE(1, "Ignore"),
+    NEW(2, "New"),
+    RECOGNIZED(3, "Recognized"),
+    FAMILIAR(4, "Familiar"),
+    LEARNED(5, "Learned"),
+    KNOWN(6, "Known");
+
+    companion object {
+        fun fromId(id: Int): KnowledgeLevel =
+            entries.find { it.id == id } ?: NEW
+    }
+}
+
+@Composable
+fun KnowledgeLevel.getBackgroundColor(): Color? = when (this) {
+    KnowledgeLevel.IGNORE, KnowledgeLevel.KNOWN -> null
+    KnowledgeLevel.NEW -> if (isSystemInDarkTheme()) Color(0xFF5D4037) else Color(0xFFFFF3E0)
+    KnowledgeLevel.RECOGNIZED -> if (isSystemInDarkTheme()) Color(0xFF0D47A1) else Color(0xFFE3F2FD)
+    KnowledgeLevel.FAMILIAR -> if (isSystemInDarkTheme()) Color(0xFF1B5E20) else Color(0xFFE8F5E9)
+    KnowledgeLevel.LEARNED -> if (isSystemInDarkTheme()) Color(0xFFF57F17) else Color(0xFFFFFDE7)
+}
+
+@Composable
+fun KnowledgeLevel.getTextColor(): Color = when (this) {
+    KnowledgeLevel.IGNORE, KnowledgeLevel.KNOWN -> Color.Unspecified
+    KnowledgeLevel.NEW -> if (isSystemInDarkTheme()) Color(0xFFFFF3E0) else Color(0xFF5D4037)
+    KnowledgeLevel.RECOGNIZED -> if (isSystemInDarkTheme()) Color(0xFFE3F2FD) else Color(0xFF0D47A1)
+    KnowledgeLevel.FAMILIAR -> if (isSystemInDarkTheme()) Color(0xFFE8F5E9) else Color(0xFF1B5E20)
+    KnowledgeLevel.LEARNED -> if (isSystemInDarkTheme()) Color(0xFFFFFDE7) else Color(0xFFF57F17)
+}

--- a/app/src/main/java/gb/coding/lightnovel/core/domain/model/KnowledgeLevel.kt
+++ b/app/src/main/java/gb/coding/lightnovel/core/domain/model/KnowledgeLevel.kt
@@ -1,7 +1,5 @@
 package gb.coding.lightnovel.core.domain.model
 
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
 enum class KnowledgeLevel(val id: Int, val label: String) {
@@ -18,20 +16,18 @@ enum class KnowledgeLevel(val id: Int, val label: String) {
     }
 }
 
-@Composable
-fun KnowledgeLevel.getBackgroundColor(): Color? = when (this) {
+fun KnowledgeLevel.getBackgroundColor(isDarkTheme: Boolean): Color? = when (this) {
     KnowledgeLevel.IGNORE, KnowledgeLevel.KNOWN -> null
-    KnowledgeLevel.NEW -> if (isSystemInDarkTheme()) Color(0xFF5D4037) else Color(0xFFFFF3E0)
-    KnowledgeLevel.RECOGNIZED -> if (isSystemInDarkTheme()) Color(0xFF0D47A1) else Color(0xFFE3F2FD)
-    KnowledgeLevel.FAMILIAR -> if (isSystemInDarkTheme()) Color(0xFF1B5E20) else Color(0xFFE8F5E9)
-    KnowledgeLevel.LEARNED -> if (isSystemInDarkTheme()) Color(0xFFF57F17) else Color(0xFFFFFDE7)
+    KnowledgeLevel.NEW -> if (isDarkTheme) Color(0xFF5D4037) else Color(0xFFFFF3E0)
+    KnowledgeLevel.RECOGNIZED -> if (isDarkTheme) Color(0xFF0D47A1) else Color(0xFFE3F2FD)
+    KnowledgeLevel.FAMILIAR -> if (isDarkTheme) Color(0xFF1B5E20) else Color(0xFFE8F5E9)
+    KnowledgeLevel.LEARNED -> if (isDarkTheme) Color(0xFFF57F17) else Color(0xFFFFFDE7)
 }
 
-@Composable
-fun KnowledgeLevel.getTextColor(): Color = when (this) {
+fun KnowledgeLevel.getTextColor(isDarkTheme: Boolean): Color = when (this) {
     KnowledgeLevel.IGNORE, KnowledgeLevel.KNOWN -> Color.Unspecified
-    KnowledgeLevel.NEW -> if (isSystemInDarkTheme()) Color(0xFFFFF3E0) else Color(0xFF5D4037)
-    KnowledgeLevel.RECOGNIZED -> if (isSystemInDarkTheme()) Color(0xFFE3F2FD) else Color(0xFF0D47A1)
-    KnowledgeLevel.FAMILIAR -> if (isSystemInDarkTheme()) Color(0xFFE8F5E9) else Color(0xFF1B5E20)
-    KnowledgeLevel.LEARNED -> if (isSystemInDarkTheme()) Color(0xFFFFFDE7) else Color(0xFFF57F17)
+    KnowledgeLevel.NEW -> if (isDarkTheme) Color(0xFFFFF3E0) else Color(0xFF5D4037)
+    KnowledgeLevel.RECOGNIZED -> if (isDarkTheme) Color(0xFFE3F2FD) else Color(0xFF0D47A1)
+    KnowledgeLevel.FAMILIAR -> if (isDarkTheme) Color(0xFFE8F5E9) else Color(0xFF1B5E20)
+    KnowledgeLevel.LEARNED -> if (isDarkTheme) Color(0xFFFFFDE7) else Color(0xFFF57F17)
 }

--- a/app/src/main/java/gb/coding/lightnovel/core/domain/model/WordKnowledge.kt
+++ b/app/src/main/java/gb/coding/lightnovel/core/domain/model/WordKnowledge.kt
@@ -1,0 +1,11 @@
+package gb.coding.lightnovel.core.domain.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class WordKnowledge(
+    val word: String,
+    val level: KnowledgeLevel,
+    val lastUpdated: Long,      // Timestamp in millis (for stats/sync)
+    val language: String,       // "de", "pt", etc., in case you add multilingual support
+)

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import gb.coding.lightnovel.core.domain.mapper.toFontFamily
 import gb.coding.lightnovel.core.domain.model.ReaderTheme
 import gb.coding.lightnovel.reader.data.mock.MockChapters
+import gb.coding.lightnovel.reader.presentation.chapter_reader.components.WordHighlightText
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderBottomBar
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderChaptersList
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderModalSettings
@@ -86,10 +87,10 @@ fun ChapterReaderScreen(
         modifier = modifier
             .background(backgroundColor)
             .pointerInput(Unit) {
-            detectTapGestures(
-                onTap = { onAction(ChapterReaderAction.OnScreenClicked) }
-            )
-        }
+                detectTapGestures(
+                    onTap = { onAction(ChapterReaderAction.OnScreenClicked) }
+                )
+            }
     ) {
         // Content
         Column(
@@ -124,13 +125,27 @@ fun ChapterReaderScreen(
             )
 
 
-            Text(
-                text = state.chapter.content,
-                color = textColor,
+            WordHighlightText(
+                fullText = state.chapter.content,
+                onWordClick = { word -> println("ChapterReaderScreen | Word clicked: \"$word\"") },
+                highlightWords = mapOf(
+                    "Wang" to Color(0xFF8E44AD),
+                    "palavras" to Color(0xFF8E44AD),
+                    "Lin" to Color(0xFF3498DB),
+                    "de" to Color(0xFF27AE60)
+                ),
                 fontSize = state.fontSize.sp,
                 letterSpacing = 1.4.sp,
                 fontFamily = state.readerFont.toFontFamily()
             )
+
+//            Text(
+//                text = state.chapter.content,
+//                color = textColor,
+//                fontSize = state.fontSize.sp,
+//                letterSpacing = 1.4.sp,
+//                fontFamily = state.readerFont.toFontFamily()
+//            )
         }
 
         // Reading progress bar
@@ -182,7 +197,13 @@ fun ChapterReaderScreen(
         ) {
             ReaderChaptersList(
                 state = state,
-                onChapterClick = { chapterId -> onAction(ChapterReaderAction.OnChapterClicked(chapterId)) }
+                onChapterClick = { chapterId ->
+                    onAction(
+                        ChapterReaderAction.OnChapterClicked(
+                            chapterId
+                        )
+                    )
+                }
             )
         }
     }

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
@@ -127,13 +127,9 @@ fun ChapterReaderScreen(
 
             WordHighlightText(
                 fullText = state.chapter.content,
+                color = textColor,
                 onWordClick = { word -> println("ChapterReaderScreen | Word clicked: \"$word\"") },
-                highlightWords = mapOf(
-                    "Wang" to Color(0xFF8E44AD),
-                    "palavras" to Color(0xFF8E44AD),
-                    "Lin" to Color(0xFF3498DB),
-                    "de" to Color(0xFF27AE60)
-                ),
+                highlightWords = emptyList(),
                 fontSize = state.fontSize.sp,
                 letterSpacing = 1.4.sp,
                 fontFamily = state.readerFont.toFontFamily()

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
@@ -38,11 +38,11 @@ import androidx.compose.ui.unit.sp
 import gb.coding.lightnovel.core.domain.mapper.toFontFamily
 import gb.coding.lightnovel.core.domain.model.ReaderTheme
 import gb.coding.lightnovel.reader.data.mock.MockChapters
-import gb.coding.lightnovel.reader.presentation.chapter_reader.components.WordHighlightText
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderBottomBar
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderChaptersList
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderModalSettings
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderTopBar
+import gb.coding.lightnovel.reader.presentation.chapter_reader.components.WordHighlightText
 import gb.coding.lightnovel.ui.theme.LightNovelTheme
 
 @Composable
@@ -128,20 +128,13 @@ fun ChapterReaderScreen(
             WordHighlightText(
                 fullText = state.chapter.content,
                 color = textColor,
+                onScreenClick = { onAction(ChapterReaderAction.OnScreenClicked) },
                 onWordClick = { word -> println("ChapterReaderScreen | Word clicked: \"$word\"") },
                 highlightWords = emptyList(),
                 fontSize = state.fontSize.sp,
                 letterSpacing = 1.4.sp,
-                fontFamily = state.readerFont.toFontFamily()
+                fontFamily = state.readerFont.toFontFamily(),
             )
-
-//            Text(
-//                text = state.chapter.content,
-//                color = textColor,
-//                fontSize = state.fontSize.sp,
-//                letterSpacing = 1.4.sp,
-//                fontFamily = state.readerFont.toFontFamily()
-//            )
         }
 
         // Reading progress bar

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/WordHighlightText.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/WordHighlightText.kt
@@ -1,0 +1,104 @@
+package gb.coding.lightnovel.reader.presentation.chapter_reader.components
+
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
+import gb.coding.lightnovel.ui.theme.LightNovelTheme
+import kotlin.text.Regex
+
+@Composable
+fun WordHighlightText(
+    fullText: String,
+    highlightWords: Map<String, Color>,
+    onWordClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+) {
+    val annotatedString = buildAnnotatedString {
+        val wordRegex = Regex("""\b\p{L}+\b""")
+        var lastIndex = 0
+
+        for (match in wordRegex.findAll(fullText)) {
+            val word = match.value
+            val start = match.range.first
+            val end = match.range.last + 1
+
+            // Add any text between the last match and this one (spaces, punctuation, etc.)
+            if (start > lastIndex) {
+                append(fullText.substring(lastIndex, start))
+            }
+
+            // Check if the word should be highlighted
+            val highlightColor = highlightWords.entries.find { word.contains(it.key) }?.value
+
+            pushStringAnnotation(tag = "WORD", annotation = word)
+            if (highlightColor != null) {
+                withStyle(SpanStyle(background = highlightColor, color = Color.Black)) {
+                    append(word)
+                }
+            } else {
+                append(word)
+            }
+            pop()
+
+            lastIndex = end
+        }
+
+        // Add any remaining text after the last word
+        if (lastIndex < fullText.length) {
+            append(fullText.substring(lastIndex))
+        }
+    }
+
+    ClickableText(
+        text = annotatedString,
+        modifier = modifier,
+        style = TextStyle(
+            fontSize = fontSize,
+            letterSpacing = letterSpacing,
+            fontFamily = fontFamily,
+        ),
+        onClick = { offset ->
+            annotatedString.getStringAnnotations("WORD", offset, offset)
+                .firstOrNull()?.let { annotation ->
+                    onWordClick(annotation.item)
+                }
+        },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UnderlineColoredTextPreview() {
+    LightNovelTheme {
+        val text = """
+        Essas palavras entraram nos ouvidos de Wang Lin e fez seus olhos ficarem sérios. 
+        
+        Uma grande quantidade de energia espiritual foi transferida dos dez fragmentos da alma para Wang Lin.
+    """.trimIndent()
+
+        val highlights = mapOf(
+            "Wang" to Color(0xFFD1C4E9),     // purple
+            "palavras" to Color(0xFFF8BBD0), // pink
+            "de" to Color(0xFFB2EBF2),       // teal
+            "grande" to Color(0xFFC8E6C9),   // light green
+            "dez" to Color(0xFFFFF59D)       // yellow
+        )
+
+        WordHighlightText(
+            fullText = text,
+            onWordClick = {},
+            highlightWords = highlights,
+        )
+    }
+}


### PR DESCRIPTION
This PR introduces per-word highlighting in the chapter reader based on the user's knowledge level, along with clickable word interactions and screen tap handling.

### Word Highlighting with Click Support
- Introduced a new composable: `WordHighlightText`
  - Replaces the previous Text composable in ChapterReaderScreen
  - Highlights specific words based on user knowledge
  - Supports per-word click detection via `onWordClick`

###  KnowledgeLevel System
- Added `KnowledgeLevel` enum (`IGNORE`, `NEW`, `RECOGNIZED`, `FAMILIAR`, `LEARNED`, `KNOWN`)
- Added `WordKnowledge` model to associate words with knowledge level, timestamp, and language
- Highlighting adapts based on knowledge level (level 1 & 6 = no background)