### PR TITLE
feat: add modal for word saving

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-04T02:01:58.225327995Z">
+        <DropdownSelection timestamp="2025-07-12T11:52:48.163104295Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=ZF524NDSNK" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/home/bento/.android/avd/Medium_Phone_API_35.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/gb/coding/lightnovel/core/domain/mapper/NovelMapper.kt
+++ b/app/src/main/java/gb/coding/lightnovel/core/domain/mapper/NovelMapper.kt
@@ -1,7 +1,10 @@
 package gb.coding.lightnovel.core.domain.mapper
 
+import gb.coding.lightnovel.core.domain.model.KnowledgeLevel
 import gb.coding.lightnovel.core.domain.model.LanguageCode
+import gb.coding.lightnovel.core.domain.model.WordKnowledge
 import gb.coding.lightnovel.reader.data.local.BookmarkedNovel
+import gb.coding.lightnovel.reader.data.local.SavedWord
 import gb.coding.lightnovel.reader.domain.models.Novel
 
 fun BookmarkedNovel.toNovel(): Novel {
@@ -24,5 +27,27 @@ fun Novel.toBookmarkedNovel(): BookmarkedNovel {
         author = author,
         languageCode = language.code,
         coverImage = coverImage,
+    )
+}
+
+fun WordKnowledge.toSavedWord(): SavedWord {
+    return SavedWord(
+        word = word,
+        language = language,
+        level = level.ordinal,
+        translation = translation,
+        imageUrl = imageUrl,
+        lastUpdated = System.currentTimeMillis(),
+    )
+}
+
+fun SavedWord.toWordKnowledge(): WordKnowledge {
+    return WordKnowledge(
+        word = word,
+        language = language,
+        translation = translation,
+        imageUrl = imageUrl,
+        level = KnowledgeLevel.fromId(level),
+        lastUpdated = System.currentTimeMillis(),
     )
 }

--- a/app/src/main/java/gb/coding/lightnovel/core/domain/model/KnowledgeLevel.kt
+++ b/app/src/main/java/gb/coding/lightnovel/core/domain/model/KnowledgeLevel.kt
@@ -3,12 +3,12 @@ package gb.coding.lightnovel.core.domain.model
 import androidx.compose.ui.graphics.Color
 
 enum class KnowledgeLevel(val id: Int, val label: String) {
-    IGNORE(1, "Ignore"),
-    NEW(2, "New"),
-    RECOGNIZED(3, "Recognized"),
-    FAMILIAR(4, "Familiar"),
-    LEARNED(5, "Learned"),
-    KNOWN(6, "Known");
+    IGNORE(0, "Ignore"),
+    NEW(1, "New"),
+    RECOGNIZED(2, "Recognized"),
+    FAMILIAR(3, "Familiar"),
+    LEARNED(4, "Learned"),
+    KNOWN(5, "Known");
 
     companion object {
         fun fromId(id: Int): KnowledgeLevel =

--- a/app/src/main/java/gb/coding/lightnovel/core/domain/model/WordKnowledge.kt
+++ b/app/src/main/java/gb/coding/lightnovel/core/domain/model/WordKnowledge.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class WordKnowledge(
     val word: String,
+    val translation: String,
+    val imageUrl: String,
     val level: KnowledgeLevel,
     val lastUpdated: Long,      // Timestamp in millis (for stats/sync)
     val language: String,       // "de", "pt", etc., in case you add multilingual support

--- a/app/src/main/java/gb/coding/lightnovel/reader/data/local/LightNovelDatabase.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/data/local/LightNovelDatabase.kt
@@ -4,11 +4,14 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 
 @Database(
-    entities = [BookmarkedNovel::class],
-    version = 1,
+    entities = [BookmarkedNovel::class, SavedWord::class],
+    version = 3,
     exportSchema = false,
 )
 abstract class LightNovelDatabase: RoomDatabase() {
 
     abstract val bookmarkedNovelDao: BookmarkedNovelDao
+
+    abstract val savedWordDao: SavedWordDao
+
 }

--- a/app/src/main/java/gb/coding/lightnovel/reader/data/local/SavedWord.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/data/local/SavedWord.kt
@@ -1,0 +1,19 @@
+package gb.coding.lightnovel.reader.data.local
+
+import androidx.room.Entity
+import gb.coding.lightnovel.core.domain.model.KnowledgeLevel
+
+@Entity(
+    tableName = "saved_words",
+    // It will guarantees there'll be only one row per word and language.
+    primaryKeys = ["word", "language"]
+)
+data class SavedWord(
+    var word: String = "",
+    var translation: String = "",
+    var imageUrl: String = "",
+    var language: String = "",
+    var level: Int = KnowledgeLevel.NEW.ordinal,
+    var createdAtd: Long = System.currentTimeMillis(),
+    var lastUpdated: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/gb/coding/lightnovel/reader/data/local/SavedWordDao.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/data/local/SavedWordDao.kt
@@ -12,4 +12,8 @@ interface SavedWordDao {
 
     @Query("SELECT * FROM saved_words WHERE word = :word")
     fun getWord(word: String): Flow<SavedWord?>
+
+    @Query("SELECT * FROM saved_words")
+    fun getAllWords(): Flow<List<SavedWord>>
+
 }

--- a/app/src/main/java/gb/coding/lightnovel/reader/data/local/SavedWordDao.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/data/local/SavedWordDao.kt
@@ -1,0 +1,15 @@
+package gb.coding.lightnovel.reader.data.local
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SavedWordDao {
+    @Upsert
+    suspend fun upsertWord(word: SavedWord)
+
+    @Query("SELECT * FROM saved_words WHERE word = :word")
+    fun getWord(word: String): Flow<SavedWord?>
+}

--- a/app/src/main/java/gb/coding/lightnovel/reader/data/repository/SavedWordRepositoryImpl.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/data/repository/SavedWordRepositoryImpl.kt
@@ -33,4 +33,11 @@ class SavedWordRepositoryImpl(
             )
         }
     }
+
+    override fun getAllWords(): Flow<List<WordKnowledge>> {
+        println("SavedWordRepositoryImpl | Getting all saved words.")
+        return savedWordDao.getAllWords().mapLatest { savedWords ->
+            savedWords.map { it.toWordKnowledge() }
+        }
+    }
 }

--- a/app/src/main/java/gb/coding/lightnovel/reader/data/repository/SavedWordRepositoryImpl.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/data/repository/SavedWordRepositoryImpl.kt
@@ -16,7 +16,7 @@ class SavedWordRepositoryImpl(
     private val savedWordDao: SavedWordDao
 ) : SavedWordRepository {
     override suspend fun addWord(word: WordKnowledge) {
-        println("SavedWordRepositoryImpl | Adding word \"${word.word}\" to saved words.")
+        println("SavedWordRepositoryImpl | Adding word \"${word.word}\" to saved words. (\"${word.language}\")")
         savedWordDao.upsertWord(word.toSavedWord())
     }
 

--- a/app/src/main/java/gb/coding/lightnovel/reader/data/repository/SavedWordRepositoryImpl.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/data/repository/SavedWordRepositoryImpl.kt
@@ -1,0 +1,36 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package gb.coding.lightnovel.reader.data.repository
+
+import gb.coding.lightnovel.core.domain.mapper.toSavedWord
+import gb.coding.lightnovel.core.domain.mapper.toWordKnowledge
+import gb.coding.lightnovel.core.domain.model.KnowledgeLevel
+import gb.coding.lightnovel.core.domain.model.WordKnowledge
+import gb.coding.lightnovel.reader.data.local.SavedWordDao
+import gb.coding.lightnovel.reader.domain.repository.SavedWordRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapLatest
+
+class SavedWordRepositoryImpl(
+    private val savedWordDao: SavedWordDao
+) : SavedWordRepository {
+    override suspend fun addWord(word: WordKnowledge) {
+        println("SavedWordRepositoryImpl | Adding word \"${word.word}\" to saved words.")
+        savedWordDao.upsertWord(word.toSavedWord())
+    }
+
+    override suspend fun getWord(word: String): Flow<WordKnowledge> {
+        println("SavedWordRepositoryImpl | Getting word \"$word\" from saved words.")
+        return savedWordDao.getWord(word).mapLatest { savedWord ->
+            savedWord?.toWordKnowledge() ?: WordKnowledge(
+                word = word,
+                level = KnowledgeLevel.NEW,
+                lastUpdated = System.currentTimeMillis(),
+                language = "en",
+                translation = "",
+                imageUrl = "",
+            )
+        }
+    }
+}

--- a/app/src/main/java/gb/coding/lightnovel/reader/di/AppModule.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/di/AppModule.kt
@@ -5,8 +5,10 @@ import gb.coding.lightnovel.BuildConfig
 import gb.coding.lightnovel.reader.data.local.LightNovelDatabase
 import gb.coding.lightnovel.reader.data.repository.BookmarkedNovelRepositoryImpl
 import gb.coding.lightnovel.reader.data.repository.NovelRepositoryImpl
+import gb.coding.lightnovel.reader.data.repository.SavedWordRepositoryImpl
 import gb.coding.lightnovel.reader.domain.repository.BookmarkedNovelRepository
 import gb.coding.lightnovel.reader.domain.repository.NovelRepository
+import gb.coding.lightnovel.reader.domain.repository.SavedWordRepository
 import gb.coding.lightnovel.reader.presentation.browse.BrowseViewModel
 import gb.coding.lightnovel.reader.presentation.chapter_reader.ChapterReaderViewModel
 import gb.coding.lightnovel.reader.presentation.library.LibraryViewModel
@@ -34,12 +36,16 @@ val appModule = module {
             context = androidContext().applicationContext,
             klass = LightNovelDatabase::class.java,
             name = "light_novel.db"
-        ).build()
+        )
+            .fallbackToDestructiveMigration(true) // Can only do it before prod.
+            .build()
     }
     single { get<LightNovelDatabase>().bookmarkedNovelDao }
+    single { get<LightNovelDatabase>().savedWordDao }
 
     singleOf(::NovelRepositoryImpl).bind<NovelRepository>()
     singleOf(::BookmarkedNovelRepositoryImpl).bind<BookmarkedNovelRepository>()
+    singleOf(::SavedWordRepositoryImpl).bind<SavedWordRepository>()
 
     viewModelOf(::BrowseViewModel)
     viewModelOf(::NovelDetailViewModel)

--- a/app/src/main/java/gb/coding/lightnovel/reader/domain/repository/SavedWordRepository.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/domain/repository/SavedWordRepository.kt
@@ -7,4 +7,6 @@ interface SavedWordRepository {
     suspend fun addWord(word: WordKnowledge)
 
     suspend fun getWord(word: String): Flow<WordKnowledge>
+
+    fun getAllWords(): Flow<List<WordKnowledge>>
 }

--- a/app/src/main/java/gb/coding/lightnovel/reader/domain/repository/SavedWordRepository.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/domain/repository/SavedWordRepository.kt
@@ -1,0 +1,10 @@
+package gb.coding.lightnovel.reader.domain.repository
+
+import gb.coding.lightnovel.core.domain.model.WordKnowledge
+import kotlinx.coroutines.flow.Flow
+
+interface SavedWordRepository {
+    suspend fun addWord(word: WordKnowledge)
+
+    suspend fun getWord(word: String): Flow<WordKnowledge>
+}

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderAction.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderAction.kt
@@ -17,7 +17,7 @@ sealed interface ChapterReaderAction {
     data class OnWordClicked(val word: String): ChapterReaderAction
     data object OnDismissWordContentDetail : ChapterReaderAction
 
-    data class OnWordKnowledgeLevelClicked(val level: Int): ChapterReaderAction
+    data class OnWordKnowledgeLevelChanged(val level: Int): ChapterReaderAction
 
     data object OnSettingsClicked: ChapterReaderAction
 

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderAction.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderAction.kt
@@ -14,6 +14,11 @@ sealed interface ChapterReaderAction {
     data class OnFontSelected(val fontFamily: ReaderFont): ChapterReaderAction
     data class OnThemeSelected(val theme: ReaderTheme): ChapterReaderAction
 
+    data class OnWordClicked(val word: String): ChapterReaderAction
+    data object OnDismissWordContentDetail : ChapterReaderAction
+
+    data class OnWordKnowledgeLevelClicked(val level: Int): ChapterReaderAction
+
     data object OnSettingsClicked: ChapterReaderAction
 
     data class OnChapterClicked(val chapterId: String): ChapterReaderAction

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
@@ -227,7 +227,7 @@ fun ChapterReaderScreen(
         ) {
             WordDetailContent(
                 word = state.wordClicked,
-                onWordLevelChanged = { onAction(ChapterReaderAction.OnWordKnowledgeLevelClicked(it)) },
+                onWordLevelChanged = { onAction(ChapterReaderAction.OnWordKnowledgeLevelChanged(it)) },
                 modifier = Modifier
                     .padding(8.dp)
                     .heightIn(maxHeight)

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -30,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -42,6 +44,7 @@ import gb.coding.lightnovel.reader.presentation.chapter_reader.components.Reader
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderChaptersList
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderModalSettings
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderTopBar
+import gb.coding.lightnovel.reader.presentation.chapter_reader.components.WordDetailContent
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.WordHighlightText
 import gb.coding.lightnovel.ui.theme.LightNovelTheme
 
@@ -129,7 +132,7 @@ fun ChapterReaderScreen(
                 fullText = state.chapter.content,
                 color = textColor,
                 onScreenClick = { onAction(ChapterReaderAction.OnScreenClicked) },
-                onWordClick = { word -> println("ChapterReaderScreen | Word clicked: \"$word\"") },
+                onWordClick = { onAction(ChapterReaderAction.OnWordClicked(it)) },
                 highlightWords = emptyList(),
                 fontSize = state.fontSize.sp,
                 letterSpacing = 1.4.sp,
@@ -209,6 +212,25 @@ fun ChapterReaderScreen(
                 onFontSizeChange = { onAction(ChapterReaderAction.OnFontSizeChanged(it)) },
                 onFontSelected = { onAction(ChapterReaderAction.OnFontSelected(it)) },
                 onThemeSelected = { onAction(ChapterReaderAction.OnThemeSelected(it)) }
+            )
+        }
+    }
+
+    // TODO: There must be a better way to do this
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    val maxHeight = screenHeight * 0.8f
+
+    if (state.showModalBottomWord) {
+        ModalBottomSheet(
+            containerColor = MaterialTheme.colorScheme.background,
+            onDismissRequest = { onAction(ChapterReaderAction.OnDismissWordContentDetail) }
+        ) {
+            WordDetailContent(
+                word = state.wordClicked,
+                onWordLevelChanged = { onAction(ChapterReaderAction.OnWordKnowledgeLevelClicked(it)) },
+                modifier = Modifier
+                    .padding(8.dp)
+                    .heightIn(maxHeight)
             )
         }
     }

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderScreen.kt
@@ -38,7 +38,9 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import gb.coding.lightnovel.core.domain.mapper.toFontFamily
+import gb.coding.lightnovel.core.domain.model.KnowledgeLevel
 import gb.coding.lightnovel.core.domain.model.ReaderTheme
+import gb.coding.lightnovel.core.domain.model.WordKnowledge
 import gb.coding.lightnovel.reader.data.mock.MockChapters
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderBottomBar
 import gb.coding.lightnovel.reader.presentation.chapter_reader.components.ReaderChaptersList
@@ -127,13 +129,12 @@ fun ChapterReaderScreen(
                     .padding(top = 4.dp, bottom = 32.dp)
             )
 
-
             WordHighlightText(
                 fullText = state.chapter.content,
                 color = textColor,
                 onScreenClick = { onAction(ChapterReaderAction.OnScreenClicked) },
                 onWordClick = { onAction(ChapterReaderAction.OnWordClicked(it)) },
-                highlightWords = emptyList(),
+                highlightWords = state.savedWords,
                 fontSize = state.fontSize.sp,
                 letterSpacing = 1.4.sp,
                 fontFamily = state.readerFont.toFontFamily(),

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderState.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderState.kt
@@ -12,9 +12,11 @@ data class ChapterReaderState(
     val fontSize: Float = 16f,
     val readerFont: ReaderFont = ReaderFont.SourceSerif4,
     val readerTheme: ReaderTheme = ReaderTheme.Light,
+    val wordClicked: String = "[NULL]",
 
     val showModalBottomSettings: Boolean = false,
     val showModalBottomChaptersList: Boolean = false,
+    val showModalBottomWord: Boolean = false,
 
     val chapterList: List<Chapter> = emptyList(),
     val currentChapterIndex: Int = -1,

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderState.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderState.kt
@@ -14,6 +14,7 @@ data class ChapterReaderState(
     val readerFont: ReaderFont = ReaderFont.SourceSerif4,
     val readerTheme: ReaderTheme = ReaderTheme.Light,
     val wordClicked: WordKnowledge? = null,
+    val savedWords: List<WordKnowledge> = emptyList(),
 
     val showModalBottomSettings: Boolean = false,
     val showModalBottomChaptersList: Boolean = false,

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderState.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderState.kt
@@ -2,6 +2,7 @@ package gb.coding.lightnovel.reader.presentation.chapter_reader
 
 import gb.coding.lightnovel.core.domain.model.ReaderFont
 import gb.coding.lightnovel.core.domain.model.ReaderTheme
+import gb.coding.lightnovel.core.domain.model.WordKnowledge
 import gb.coding.lightnovel.reader.domain.models.Chapter
 
 data class ChapterReaderState(
@@ -12,7 +13,7 @@ data class ChapterReaderState(
     val fontSize: Float = 16f,
     val readerFont: ReaderFont = ReaderFont.SourceSerif4,
     val readerTheme: ReaderTheme = ReaderTheme.Light,
-    val wordClicked: String = "[NULL]",
+    val wordClicked: WordKnowledge? = null,
 
     val showModalBottomSettings: Boolean = false,
     val showModalBottomChaptersList: Boolean = false,

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderViewModel.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderViewModel.kt
@@ -3,6 +3,7 @@ package gb.coding.lightnovel.reader.presentation.chapter_reader
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import gb.coding.lightnovel.core.domain.model.KnowledgeLevel
 import gb.coding.lightnovel.core.domain.util.onError
 import gb.coding.lightnovel.core.domain.util.onSuccess
 import gb.coding.lightnovel.reader.domain.repository.NovelRepository
@@ -95,6 +96,27 @@ class ChapterReaderViewModel(
             is ChapterReaderAction.OnThemeSelected -> {
                 println("ChapterReaderViewModel | OnThemeSelected | Theme: ${action.theme}")
                 _state.value = _state.value.copy(readerTheme = action.theme)
+            }
+
+            is ChapterReaderAction.OnWordClicked -> {
+                println("ChapterReaderViewModel | OnWordClicked | Word: \"${action.word}\"")
+                _state.value = _state.value.copy(
+                    wordClicked = action.word,
+                    showModalBottomWord = true,
+                    showModalBottomSettings = false,
+                    showModalBottomChaptersList = false,
+                )
+            }
+            ChapterReaderAction.OnDismissWordContentDetail -> {
+                println("ChapterReaderViewModel | OnDismissWordContentDetail")
+                _state.value = _state.value.copy(
+                    showModalBottomWord = false,
+                )
+            }
+
+            is ChapterReaderAction.OnWordKnowledgeLevelClicked -> {
+                val level = KnowledgeLevel.fromId(action.level)
+                println("ChapterReaderViewModel | OnWordKnowledgeLevelClicked | Level: ${level.name}")
             }
 
             ChapterReaderAction.OnReturnClicked -> {

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderViewModel.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/ChapterReaderViewModel.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package gb.coding.lightnovel.reader.presentation.chapter_reader
 
 import androidx.lifecycle.SavedStateHandle
@@ -8,6 +10,7 @@ import gb.coding.lightnovel.core.domain.util.onError
 import gb.coding.lightnovel.core.domain.util.onSuccess
 import gb.coding.lightnovel.reader.domain.repository.NovelRepository
 import gb.coding.lightnovel.reader.domain.repository.SavedWordRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,6 +37,15 @@ class ChapterReaderViewModel(
     init {
         val chapterId: String = checkNotNull(savedStateHandle["chapterId"]) {
             println("ChapterReaderViewModel | init | Error getting chapterId from savedStateHandle")
+        }
+
+        viewModelScope.launch {
+            println("ChapterReaderViewModel | init | Loading saved words")
+            savedWordRepository
+                .getAllWords()
+                .collectLatest { words ->
+                    _state.value = _state.value.copy(savedWords = words)
+                }
         }
 
         viewModelScope.launch {

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/KnowledgeLevelSelector.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/KnowledgeLevelSelector.kt
@@ -1,0 +1,118 @@
+package gb.coding.lightnovel.reader.presentation.chapter_reader.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import gb.coding.lightnovel.R
+import gb.coding.lightnovel.ui.theme.LightNovelTheme
+
+@Composable
+fun KnowledgeLevelSelector(
+    selectedLevel: Int?,
+    onLevelSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val labels = listOf("Ignore", "New", "Recognized", "Familiar", "Learned", "Known")
+
+    // There must be a better way to do this -.-'
+    val levelItems: List<@Composable (isSelected: Boolean) -> Unit> = listOf(
+        { Icon(painter = painterResource(R.drawable.delete), contentDescription = "Ignore", tint = if (it) Color.White else MaterialTheme.colorScheme.onBackground) },
+        { Text("1", fontSize = 16.sp, color = if (it) Color.White else MaterialTheme.colorScheme.onBackground) },
+        { Text("2", fontSize = 16.sp, color = if (it) Color.White else MaterialTheme.colorScheme.onBackground) },
+        { Text("3", fontSize = 16.sp, color = if (it) Color.White else MaterialTheme.colorScheme.onBackground) },
+        { Text("4", fontSize = 16.sp, color = if (it) Color.White else MaterialTheme.colorScheme.onBackground) },
+        { Icon(painter = painterResource(R.drawable.check), contentDescription = "Known", tint = if (it) Color.White else MaterialTheme.colorScheme.onBackground) }
+    )
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Knowledge Level",
+            color = MaterialTheme.colorScheme.onBackground,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                // .padding(horizontal = 12.dp)
+        ) {
+            val borderColor = if (isSystemInDarkTheme()) Color(0xFF4A4A4A) else Color(0xFFD9D9D9)
+
+            levelItems.forEachIndexed { index, content ->
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    val isSelected = selectedLevel == index
+                    Box(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .clip(CircleShape)
+                            .run{
+                                if (!isSelected) this.border(width = 1.dp, color = borderColor, shape = CircleShape)
+                                else this
+                            }
+                            .background(
+                                if (isSelected) Color(0xFF66558E)
+                                else MaterialTheme.colorScheme.background
+                            )
+                            .clickable { onLevelSelected(index) },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        content(isSelected)
+                    }
+
+                    if (isSelected) {
+                        Text(
+                            text = labels[index],
+                            fontSize = 12.sp,
+                            color = Color(0xFF66558E),
+                            modifier = Modifier.padding(top = 4.dp),
+                            textAlign = TextAlign.Center
+                        )
+                    } else {
+                        Spacer(modifier = Modifier.height(20.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun KnowledgeLevelSelectorPreview() {
+    LightNovelTheme {
+        KnowledgeLevelSelector(
+            selectedLevel = 3,
+            onLevelSelected = {},
+            modifier = Modifier.padding(8.dp)
+        )
+    }
+}

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/SearchImagePlaceholder.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/SearchImagePlaceholder.kt
@@ -1,0 +1,85 @@
+package gb.coding.lightnovel.reader.presentation.chapter_reader.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import gb.coding.lightnovel.R
+import gb.coding.lightnovel.ui.theme.LightNovelTheme
+
+@Composable
+fun SearchImagePlaceholder(modifier: Modifier = Modifier) {
+    val borderColor = if (isSystemInDarkTheme()) Color(0xFF4A4A4A) else Color(0xFFD9D9D9)
+
+    // Todo: use a better approach to get the screen height
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    val imageHeight = screenHeight * 0.3f
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(imageHeight)
+            .aspectRatio(16f / 9f)
+            .border(
+                width = 1.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.background)
+            .clickable { /* No-op for now */ }
+            .padding(16.dp)
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                painter = painterResource(R.drawable.add_photo_alternate),
+                contentDescription = "Search image",
+                tint = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.size(100.dp)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Search an image for this word...",
+                color = MaterialTheme.colorScheme.onBackground,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SearchImagePlaceholderPreview() {
+    LightNovelTheme {
+        SearchImagePlaceholder(
+            modifier = Modifier.padding(8.dp)
+        )
+    }
+}

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/WordDetailContent.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/WordDetailContent.kt
@@ -22,16 +22,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import gb.coding.lightnovel.core.domain.model.KnowledgeLevel
+import gb.coding.lightnovel.core.domain.model.LanguageCode
+import gb.coding.lightnovel.core.domain.model.WordKnowledge
 import gb.coding.lightnovel.ui.theme.LightNovelTheme
 
 @Composable
 fun WordDetailContent(
-    word: String,
+    word: WordKnowledge?,
     onWordLevelChanged: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // Just for demo purposes
-    var selectedLevel by remember { mutableIntStateOf(3) }
     var translationText by remember { mutableStateOf("") }
 
     Column(
@@ -40,7 +42,7 @@ fun WordDetailContent(
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(
-                text = word,
+                text = word?.word ?: "Word",
                 fontSize = 18.sp,
                 fontWeight = FontWeight.SemiBold,
             )
@@ -68,10 +70,8 @@ fun WordDetailContent(
         }
 
         KnowledgeLevelSelector(
-            selectedLevel = selectedLevel,
+            selectedLevel = word?.level?.id ?: 1,
             onLevelSelected = { level ->
-                selectedLevel = level
-                // Just for demo purposes
                 onWordLevelChanged(level)
             }
         )
@@ -87,12 +87,21 @@ fun WordDetailContent(
     }
 }
 
+internal val wordKnowledgePreview = WordKnowledge(
+    word = "Zimmer",
+    translation = "Quarto",
+    imageUrl = "",
+    level = KnowledgeLevel.IGNORE,
+    lastUpdated = System.currentTimeMillis(),
+    language = LanguageCode.GERMAN.code,
+)
+
 @Preview(showBackground = true)
 @Composable
 private fun WordDetailContentPreview() {
     LightNovelTheme {
         WordDetailContent(
-            word = "Zimmer",
+            word = wordKnowledgePreview,
             onWordLevelChanged = {},
             modifier = Modifier.padding(8.dp)
         )

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/WordDetailContent.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/WordDetailContent.kt
@@ -1,0 +1,100 @@
+package gb.coding.lightnovel.reader.presentation.chapter_reader.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import gb.coding.lightnovel.ui.theme.LightNovelTheme
+
+@Composable
+fun WordDetailContent(
+    word: String,
+    onWordLevelChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Just for demo purposes
+    var selectedLevel by remember { mutableIntStateOf(3) }
+    var translationText by remember { mutableStateOf("") }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = word,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            HorizontalDivider()
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = "Translation",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            TextField(
+                value = translationText,
+                onValueChange = { translationText = it },
+                placeholder = { Text(text = "Translation...") },
+                colors = TextFieldDefaults.colors(
+                    // I can edit background here...
+                    unfocusedIndicatorColor = Color.Transparent,
+                    focusedIndicatorColor = Color.Transparent,
+                ),
+                shape = RoundedCornerShape(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        KnowledgeLevelSelector(
+            selectedLevel = selectedLevel,
+            onLevelSelected = { level ->
+                selectedLevel = level
+                // Just for demo purposes
+                onWordLevelChanged(level)
+            }
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = "Image",
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            SearchImagePlaceholder()
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WordDetailContentPreview() {
+    LightNovelTheme {
+        WordDetailContent(
+            word = "Zimmer",
+            onWordLevelChanged = {},
+            modifier = Modifier.padding(8.dp)
+        )
+    }
+}

--- a/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/WordHighlightText.kt
+++ b/app/src/main/java/gb/coding/lightnovel/reader/presentation/chapter_reader/components/WordHighlightText.kt
@@ -24,6 +24,7 @@ import gb.coding.lightnovel.core.domain.model.KnowledgeLevel
 import gb.coding.lightnovel.core.domain.model.WordKnowledge
 import gb.coding.lightnovel.core.domain.model.getBackgroundColor
 import gb.coding.lightnovel.core.domain.model.getTextColor
+import gb.coding.lightnovel.reader.data.local.SavedWord
 import gb.coding.lightnovel.ui.theme.LightNovelTheme
 
 @Composable

--- a/app/src/main/res/drawable-nodpi/add_photo_alternate.xml
+++ b/app/src/main/res/drawable-nodpi/add_photo_alternate.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18,20L4,20L4,6h9L13,4L4,4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2v-9h-2v9zM10.21,16.83l-1.96,-2.36L5.5,18h11l-3.54,-4.71zM20,4L20,1h-2v3h-3c0.01,0.01 0,2 0,2h3v2.99c0.01,0.01 2,0 2,0L20,6h3L23,4h-3z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/app/src/main/res/drawable-nodpi/check.xml
+++ b/app/src/main/res/drawable-nodpi/check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M382,720 L154,492l57,-57 171,171 367,-367 57,57 -424,424Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/app/src/main/res/drawable-nodpi/delete.xml
+++ b/app/src/main/res/drawable-nodpi/delete.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M280,840q-33,0 -56.5,-23.5T200,760v-520h-40v-80h200v-40h240v40h200v80h-40v520q0,33 -23.5,56.5T680,840L280,840ZM680,240L280,240v520h400v-520ZM360,680h80v-360h-80v360ZM520,680h80v-360h-80v360ZM280,240v520,-520Z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
### Summary:
Adds a bottom sheet for viewing and editing word details in the chapter reader, with persistent storage for WordKnowledge and highlighted saved words.

- Word detail modal with translation, knowledge level, and image placeholder.
- Saved words stored via new entity, DAO, and repository.
- Integrated WordKnowledge into chapter reader and detail view.
- Highlight saved words in text.

https://github.com/user-attachments/assets/d50ed09e-d510-4d50-a121-7dac6a5ba404

